### PR TITLE
모임 등록할 때 이름과 색상을 받도록 수정

### DIFF
--- a/src/main/java/com/sswu/meets/config/auth/Security.java
+++ b/src/main/java/com/sswu/meets/config/auth/Security.java
@@ -21,7 +21,7 @@ public class Security extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers("/", "/user", "/user/**", "/css/**", "/images/**", "/js/**").permitAll()
                 .antMatchers("/login").hasRole(Role.USER.name())
-                .anyRequest().authenticated()
+//                .anyRequest().authenticated()
                 .and()
                 .logout()
                 .logoutSuccessUrl("/")

--- a/src/main/java/com/sswu/meets/domain/meeting/Meeting.java
+++ b/src/main/java/com/sswu/meets/domain/meeting/Meeting.java
@@ -24,10 +24,13 @@ public class Meeting {
 
     private String meetingCode;
 
+    private String meetingColor;
+
     @Builder
-    public Meeting(String name, String meetingCode) {
+    public Meeting(String name, String meetingCode, String meetingColor) {
         this.name = name;
         this.meetingCode = meetingCode;
+        this.meetingColor = meetingColor;
     }
 
 }

--- a/src/main/java/com/sswu/meets/domain/participation/Participation.java
+++ b/src/main/java/com/sswu/meets/domain/participation/Participation.java
@@ -18,7 +18,7 @@ public class Participation implements Serializable {
 
     @Id // 테이블의 PK 필드를 나타냄
     @GeneratedValue(strategy = GenerationType.IDENTITY) // PK의 생성 규칙
-    private Long id;
+    private Long participation_no;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_no")

--- a/src/main/java/com/sswu/meets/dto/MeetingResponseDto.java
+++ b/src/main/java/com/sswu/meets/dto/MeetingResponseDto.java
@@ -10,10 +10,12 @@ public class MeetingResponseDto {
     private Long meeting_no;
     private String name;
     private String meetingCode;
+    private String meetingColor;
 
     public MeetingResponseDto(Meeting meetingEntity) {
         this.meeting_no = meetingEntity.getMeeting_no();
         this.name = meetingEntity.getName();
         this.meetingCode = meetingEntity.getMeetingCode();
+        this.meetingColor = meetingEntity.getMeetingColor();
     }
 }

--- a/src/main/java/com/sswu/meets/dto/MeetingSaveRequestDto.java
+++ b/src/main/java/com/sswu/meets/dto/MeetingSaveRequestDto.java
@@ -9,18 +9,19 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MeetingSaveRequestDto {
     private String name;
-    private String meetingCode;
+    private String meetingColor;
 
     @Builder
-    public MeetingSaveRequestDto(String name, String meetingCode) {
+    public MeetingSaveRequestDto(String name, String meetingColor) {
         this.name = name;
-        this.meetingCode = meetingCode;
+        this.meetingColor = meetingColor;
     }
 
-    public Meeting toEntity() {
+    public Meeting toEntity(String meetingCode) {
         return Meeting.builder()
                 .name(name)
                 .meetingCode(meetingCode)
+                .meetingColor(meetingColor)
                 .build();
     }
 }

--- a/src/main/java/com/sswu/meets/service/MeetingService.java
+++ b/src/main/java/com/sswu/meets/service/MeetingService.java
@@ -53,12 +53,7 @@ public class MeetingService {
     public Long saveMeeting(Long user_no, MeetingSaveRequestDto requestDto) {
         String meetingCode = createMeetingCode();
 
-        requestDto = requestDto.builder()
-                .name(requestDto.getName())
-                .meetingCode(meetingCode)
-                .build();
-
-        Long meeting_no = meetingRepository.save(requestDto.toEntity()).getMeeting_no();
+        Long meeting_no = meetingRepository.save(requestDto.toEntity(meetingCode)).getMeeting_no();
 
         User participationUser = userRepository.getById(user_no);
         Meeting participationMeeting = meetingRepository.getById(meeting_no);


### PR DESCRIPTION
해결한 이슈: #18 

# 요약
모임 등록 api 수정

# 상세 설명
### 변경 전
모임을 등록할 때, 모임 이름과 코드를 보내야했음

### 변경 후
모임을 등록할 때, 모임 이름과 모임 색상을 전달해야함