### PR TITLE
탈퇴하기와 유저 정보 수정하기 api에서 user_no 제거

### DIFF
--- a/src/main/java/com/sswu/meets/controller/UserController.java
+++ b/src/main/java/com/sswu/meets/controller/UserController.java
@@ -67,15 +67,18 @@ public class UserController {
     }
 
     @ApiOperation(value = "유저 정보 수정")
-    @PutMapping("/user/{user_no}")
-    public boolean update(@PathVariable Long user_no, @RequestBody UserUpdateRequestDto userSaveRequestDto){
-        return userService.update(user_no, userSaveRequestDto);
+    @PutMapping("/user")
+    public boolean update(@RequestBody UserUpdateRequestDto userSaveRequestDto){
+        SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
+        return userService.update(sessionUser.getUserNo(), userSaveRequestDto);
     }
 
     @ApiOperation(value = "탈퇴하기")
-    @DeleteMapping("/user/{user_no}")
-    public boolean deleteUser(@PathVariable Long user_no) {
-        return userService.deleteUser(user_no);
+    @DeleteMapping("/user")
+    public boolean deleteUser() {
+        SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
+        httpSession.invalidate();
+        return userService.deleteUser(sessionUser.getUserNo());
     }
 
     @ApiOperation(value = "로그인", notes = "구글 로그인 페이지로 이동")


### PR DESCRIPTION
해결한 이슈: #25 

url에서 user_no를 클라이언트를 통해 전달받는 것이 아니라, 세션에서 유저 정보를 가져올 수 있도록 변경