### PR TITLE
best3 결과 조회 api 추가

### DIFF
--- a/src/main/java/com/sswu/meets/controller/TuneTimeController.java
+++ b/src/main/java/com/sswu/meets/controller/TuneTimeController.java
@@ -1,11 +1,27 @@
 package com.sswu.meets.controller;
 
+import com.sswu.meets.domain.tuneTime.TuneTimeRepository;
+import com.sswu.meets.dto.Best3ResponseDto;
+import com.sswu.meets.service.TuneTimeService;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
+
+import java.util.List;
 
 @ApiIgnore
 @RequiredArgsConstructor
 @RestController
 public class TuneTimeController {
+
+    private final TuneTimeService tuneTimeService;
+
+    @ApiOperation(value = "가능한 시간 BEST3")
+    @GetMapping("/tune/best/{scheduleNo}")
+    public List<Best3ResponseDto> calculateBestTime(@PathVariable Long scheduleNo) {
+        return tuneTimeService.calculateBestTime(scheduleNo);
+    }
 }

--- a/src/main/java/com/sswu/meets/domain/tuneTime/TuneTimeRepository.java
+++ b/src/main/java/com/sswu/meets/domain/tuneTime/TuneTimeRepository.java
@@ -5,8 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 public interface TuneTimeRepository extends JpaRepository<TuneTime, Long> {
     TuneTime findByScheduleAndTuneDateAndTuneTime(Schedule schedule, LocalDate tuneDate, LocalTime tuneTime);
     TuneTime findBySchedule(Schedule schedule);
+
+    List<TuneTime> findAllByScheduleOrderByAvPeopleNoDescTuneTime(Schedule schedule);
 }

--- a/src/main/java/com/sswu/meets/dto/Best3ResponseDto.java
+++ b/src/main/java/com/sswu/meets/dto/Best3ResponseDto.java
@@ -1,0 +1,50 @@
+package com.sswu.meets.dto;
+
+import com.sswu.meets.domain.tuneTime.TuneTime;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+public class Best3ResponseDto {
+
+    @ApiModelProperty(example = "2022-08-17")
+    private LocalDate bestDate;
+
+    @ApiModelProperty(example = "11:00")
+    private LocalTime startTime;
+
+    @ApiModelProperty(example = "13:00")
+    private LocalTime endTime;
+
+    @ApiModelProperty(example = "3")
+    private Long avPeopleNo;
+
+    @Builder
+    public Best3ResponseDto(LocalDate bestDate, LocalTime startTime, LocalTime endTime, Long avPeopleNo) {
+        this.bestDate = bestDate;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.avPeopleNo = avPeopleNo;
+    }
+
+    public Best3ResponseDto updateEndTime(LocalTime endTime) {
+        this.endTime = endTime;
+
+        return this;
+    }
+
+    public Best3ResponseDto toBest3Item(TuneTime tuneTime) {
+        return Best3ResponseDto.builder()
+                .bestDate(tuneTime.getTuneDate())
+                .startTime(tuneTime.getTuneTime())
+                .endTime(tuneTime.getTuneTime().plusMinutes(30))
+                .avPeopleNo(tuneTime.getAvPeopleNo())
+                .build();
+    }
+}

--- a/src/main/java/com/sswu/meets/service/ScheduleService.java
+++ b/src/main/java/com/sswu/meets/service/ScheduleService.java
@@ -71,7 +71,7 @@ public class ScheduleService {
     @Transactional
     public Boolean update(Long scheduleNo, ScheduleUpdateRequestDto scheduleUpdateRequestDto) {
         Schedule schedule = scheduleRepository.findById(scheduleNo)
-                .orElseThrow(() -> new IllegalArgumentException("해당 일정은 없습니다. scheduleNo=" + scheduleNo));
+                .orElseThrow(() -> new IllegalArgumentException("해당 일정은 존재하지 않습니. scheduleNo=" + scheduleNo));
         schedule.update(scheduleUpdateRequestDto.getScheduleName());
 
         return true;
@@ -80,7 +80,7 @@ public class ScheduleService {
     // 일정 삭제
     public Boolean delete(Long scheduleNo) {
         Schedule schedule = scheduleRepository.findById(scheduleNo)
-                .orElseThrow(() -> new IllegalArgumentException("해당 일정은 없습니다. scheduleNo=" + scheduleNo));
+                .orElseThrow(() -> new IllegalArgumentException("해당 일정은 존재하지 않습니다. scheduleNo=" + scheduleNo));
         scheduleRepository.delete(schedule);
 
         return true;

--- a/src/main/java/com/sswu/meets/service/TuneTimeService.java
+++ b/src/main/java/com/sswu/meets/service/TuneTimeService.java
@@ -21,38 +21,36 @@ public class TuneTimeService {
     private final TuneTimeRepository tuneTimeRepository;
     private final ScheduleRepository scheduleRepository;
 
+    /*
+    * Best3에 저장된 객체가 없을 때는 추가
+    * 마지막 객체의 종료시간과 현재 객체의 시작시간이 같으면, 마지막 객체의 종료시간을 30분 연장. 다르면 새로 추가.
+    */
     @Transactional
     public List<Best3ResponseDto> calculateBestTime(Long scheduleNo) {
         Schedule schedule = scheduleRepository.findById(scheduleNo)
-                .orElseThrow(() -> new IllegalArgumentException("해당 일정은 없습니다. scheduleNo=" + scheduleNo));
+                .orElseThrow(() -> new IllegalArgumentException("해당 일정은 존재하지 않습니다. scheduleNo=" + scheduleNo));
 
         List<Best3ResponseDto> best3result = new ArrayList<>();
         for (TuneTime tuneTimeListItem : tuneTimeRepository.findAllByScheduleOrderByAvPeopleNoDescTuneTime(schedule)) {
-
-            log.info("best3size: {}개", best3result.size());
 
             if (best3result.size() == 3) {
                 break;
             }
 
-            if (best3result.isEmpty()) { // 저장된 Best3 아이템이 없을 때는 추가
+            if (best3result.isEmpty()) {
                 Best3ResponseDto best3ResponseDto = new Best3ResponseDto();
                 best3result.add(best3ResponseDto.toBest3Item(tuneTimeListItem));
-                log.info("Best3-{} 추가(39):{} | {} ~ {}", best3result.size(), tuneTimeListItem.getTuneDate(), tuneTimeListItem.getTuneTime(), tuneTimeListItem.getTuneTime().plusMinutes(30));
-            } else { // (저장된 아이템이 있는 경우) 전 아이템의 endTime과 현재 아이템의 startTime이 같으면 전 아이템의 endTime을 30분 연장, 다르면 새로 추가
+            } else {
                 int lastIndex = best3result.size() - 1;
                 Best3ResponseDto best3resultLastItem = best3result.get(lastIndex);
 
                 if (tuneTimeListItem.getTuneTime().equals(best3resultLastItem.getEndTime())) {
                     best3resultLastItem.updateEndTime(tuneTimeListItem.getTuneTime().plusMinutes(30));
-                    log.info("Best3-{} 수정:{} | {} ~ {}", best3result.size(), best3resultLastItem.getBestDate(), best3resultLastItem.getStartTime(), best3resultLastItem.getEndTime());
                 } else {
                     Best3ResponseDto best3ResponseDto = new Best3ResponseDto();
                     best3result.add(best3ResponseDto.toBest3Item(tuneTimeListItem));
-                    log.info("Best3-{} 추가(50):{} | {} ~ {}", best3result.size(), tuneTimeListItem.getTuneDate(), tuneTimeListItem.getTuneTime(), tuneTimeListItem.getTuneTime().plusMinutes(30));
                 }
             }
-            log.info("==============================================================");
         }
         return best3result;
     }

--- a/src/main/java/com/sswu/meets/service/TuneTimeService.java
+++ b/src/main/java/com/sswu/meets/service/TuneTimeService.java
@@ -1,9 +1,60 @@
 package com.sswu.meets.service;
 
+import com.sswu.meets.domain.schedule.Schedule;
+import com.sswu.meets.domain.schedule.ScheduleRepository;
+import com.sswu.meets.domain.tuneTime.TuneTime;
+import com.sswu.meets.domain.tuneTime.TuneTimeRepository;
+import com.sswu.meets.dto.Best3ResponseDto;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class TuneTimeService {
+
+    private final TuneTimeRepository tuneTimeRepository;
+    private final ScheduleRepository scheduleRepository;
+
+    @Transactional
+    public List<Best3ResponseDto> calculateBestTime(Long scheduleNo) {
+        Schedule schedule = scheduleRepository.findById(scheduleNo)
+                .orElseThrow(() -> new IllegalArgumentException("해당 일정은 없습니다. scheduleNo=" + scheduleNo));
+
+        List<Best3ResponseDto> best3result = new ArrayList<>();
+        for (TuneTime tuneTimeListItem : tuneTimeRepository.findAllByScheduleOrderByAvPeopleNoDescTuneTime(schedule)) {
+
+            log.info("best3size: {}개", best3result.size());
+
+            if (best3result.size() == 3) {
+                break;
+            }
+
+            if (best3result.isEmpty()) { // 저장된 Best3 아이템이 없을 때는 추가
+                Best3ResponseDto best3ResponseDto = new Best3ResponseDto();
+                best3result.add(best3ResponseDto.toBest3Item(tuneTimeListItem));
+                log.info("Best3-{} 추가(39):{} | {} ~ {}", best3result.size(), tuneTimeListItem.getTuneDate(), tuneTimeListItem.getTuneTime(), tuneTimeListItem.getTuneTime().plusMinutes(30));
+            } else { // (저장된 아이템이 있는 경우) 전 아이템의 endTime과 현재 아이템의 startTime이 같으면 전 아이템의 endTime을 30분 연장, 다르면 새로 추가
+                int lastIndex = best3result.size() - 1;
+                Best3ResponseDto best3resultLastItem = best3result.get(lastIndex);
+
+                if (tuneTimeListItem.getTuneTime().equals(best3resultLastItem.getEndTime())) {
+                    best3resultLastItem.updateEndTime(tuneTimeListItem.getTuneTime().plusMinutes(30));
+                    log.info("Best3-{} 수정:{} | {} ~ {}", best3result.size(), best3resultLastItem.getBestDate(), best3resultLastItem.getStartTime(), best3resultLastItem.getEndTime());
+                } else {
+                    Best3ResponseDto best3ResponseDto = new Best3ResponseDto();
+                    best3result.add(best3ResponseDto.toBest3Item(tuneTimeListItem));
+                    log.info("Best3-{} 추가(50):{} | {} ~ {}", best3result.size(), tuneTimeListItem.getTuneDate(), tuneTimeListItem.getTuneTime(), tuneTimeListItem.getTuneTime().plusMinutes(30));
+                }
+            }
+            log.info("==============================================================");
+        }
+        return best3result;
+    }
+
 }


### PR DESCRIPTION
해결한 이슈: #48 
* 가장 많은 인원이 참여가능한 날짜와 시간 Best 3를 조회
* 예시
```
[
    {
        "bestDate": "2022-08-01",
        "startTime": "11:00:00",
        "endTime": "13:00:00",
        "avPeopleNo": 3
    },
    {
        "bestDate": "2022-08-03",
        "startTime": "18:00:00",
        "endTime": "20:00:00",
        "avPeopleNo": 3
    },
    {
        "bestDate": "2022-08-01",
        "startTime": "10:00:00",
        "endTime": "10:30:00",
        "avPeopleNo": 2
    }
]
```

* 아직은 더 길게 가능한 시간을 우선적으로 반환하지 않음. -> 시간이 남으면, 기능 향상시키기
* 조율 데이터 저장할 때, 중복되지 않도록