### PR TITLE
로그인 api 수정

### DIFF
--- a/src/main/java/com/sswu/meets/config/WebConfig.java
+++ b/src/main/java/com/sswu/meets/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.sswu.meets.config;
+
+import com.sswu.meets.config.auth.LoginUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private final LoginUserArgumentResolver loginUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(loginUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/sswu/meets/config/auth/LoginSuccessHandler.java
+++ b/src/main/java/com/sswu/meets/config/auth/LoginSuccessHandler.java
@@ -1,0 +1,24 @@
+package com.sswu.meets.config.auth;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        log.info("Login Success");
+
+        response.sendRedirect("/user");
+    }
+
+}

--- a/src/main/java/com/sswu/meets/config/auth/LoginUser.java
+++ b/src/main/java/com/sswu/meets/config/auth/LoginUser.java
@@ -1,0 +1,12 @@
+package com.sswu.meets.config.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser {
+}
+

--- a/src/main/java/com/sswu/meets/config/auth/LoginUserArgumentResolver.java
+++ b/src/main/java/com/sswu/meets/config/auth/LoginUserArgumentResolver.java
@@ -1,0 +1,31 @@
+package com.sswu.meets.config.auth;
+
+import com.sswu.meets.config.auth.dto.SessionUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpSession;
+
+@RequiredArgsConstructor
+@Component
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+    private final HttpSession httpSession;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean isLoginUserAnnotation = parameter.getParameterAnnotation(LoginUser.class) != null;
+        boolean isUserClass = SessionUser.class.equals(parameter.getParameterType());
+
+        return isLoginUserAnnotation && isUserClass;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        return httpSession.getAttribute("user");
+    }
+}

--- a/src/main/java/com/sswu/meets/config/auth/Security.java
+++ b/src/main/java/com/sswu/meets/config/auth/Security.java
@@ -11,6 +11,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 @EnableWebSecurity
 public class Security extends WebSecurityConfigurerAdapter {
     private final CustomOAuth2UserService customOAuth2UserService;
+    private final LoginSuccessHandler loginSuccessHandler;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
@@ -28,6 +29,8 @@ public class Security extends WebSecurityConfigurerAdapter {
                 .and()
                 .oauth2Login()
                 .userInfoEndpoint()
-                .userService(customOAuth2UserService);
+                .userService(customOAuth2UserService)
+                .and()
+                .successHandler(loginSuccessHandler);
     }
 }

--- a/src/main/java/com/sswu/meets/controller/UserController.java
+++ b/src/main/java/com/sswu/meets/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.sswu.meets.controller;
 
+import com.sswu.meets.config.auth.LoginUser;
 import com.sswu.meets.config.auth.dto.SessionUser;
 import com.sswu.meets.dto.MeetingResponseDto;
 import com.sswu.meets.dto.UserResponseDto;
@@ -27,10 +28,9 @@ public class UserController {
 
     @ApiOperation(value = "홈 api", notes = "로그인 한 유저의 경우, OO님 환영합니다. | 로그인 하지 않은 유저의 경우, \"meets에 오신 걸 환영합니다:)\"")
     @GetMapping("/")
-    public String hello() {
-        SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
-        if (sessionUser != null) {
-            String userName = sessionUser.getName();
+    public String hello(@LoginUser SessionUser user) {
+        if (user != null) {
+            String userName = user.getName();
             return userName + "님 환영합니다.";
         } else {
             return "meets에 오신 걸 환영합니다:)";
@@ -44,54 +44,47 @@ public class UserController {
     }
 
     @ApiOperation(value = "모든 유저 정보 조회")
-    @GetMapping("/user")
+    @GetMapping("/user/all")
     public List<UserResponseDto> getUserList() {
         return userService.getUserList();
     }
 
-    @ApiOperation(value = "유저가 참여하고 있는 모든 모임 조회")
-    @GetMapping("/user/meetinglist")
-    public List<MeetingResponseDto> getMeetingListOfUser() {
-        SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
-
-        return userService.getMeetingList(sessionUser.getUserNo());
-    }
-
-    @ApiOperation(value = "마이페이지", notes = "\"로그인 한 유저의 경우, 유저 정보 반환 | 로그인 하지 않은 유저의 경우, \"로그인을 먼저 해주세요.\" 안내 메세지 반환")
-    @GetMapping("/user/mypage")
-    public Object getUserInfo() {
-        SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
-        if (sessionUser != null) {
-            return sessionUser;
+    @ApiOperation(value = "유저 정보 조회", notes = "\"로그인 한 유저의 경우, 유저 정보 반환 | 로그인 하지 않은 유저의 경우, \"로그인을 먼저 해주세요.\" 안내 메세지 반환")
+    @GetMapping("/user")
+    public Object getUserInfo(@LoginUser SessionUser user) {
+        if (user != null) {
+            return user;
         } else {
             return "로그인을 먼저 해주세요.";
         }
     }
 
+    @ApiOperation(value = "유저가 참여하고 있는 모든 모임 조회")
+    @GetMapping("/user/meetinglist")
+    public List<MeetingResponseDto> getMeetingListOfUser(@LoginUser SessionUser user) {
+        return userService.getMeetingList(user.getUserNo());
+    }
+
     @ApiOperation(value = "유저 정보 수정")
     @PutMapping("/user")
-    public Boolean update(@RequestBody UserUpdateRequestDto userSaveRequestDto){
-        SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
-        return userService.update(sessionUser.getUserNo(), userSaveRequestDto);
+    public Boolean update(@LoginUser SessionUser user, @RequestBody UserUpdateRequestDto userSaveRequestDto){
+        return userService.update(user.getUserNo(), userSaveRequestDto);
     }
 
     @ApiOperation(value = "탈퇴하기")
     @DeleteMapping("/user")
-    public Boolean deleteUser() {
-        SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
+    public Boolean deleteUser(@LoginUser SessionUser user) {
         httpSession.invalidate();
-        return userService.deleteUser(sessionUser.getUserNo());
+        return userService.deleteUser(user.getUserNo());
     }
 
-    @ApiOperation(value = "로그인", notes = "구글 로그인 페이지로 이동")
+    @ApiOperation(value = "로그인", notes = "구글 로그인 페이지로 이동. 성공시 \"/user/\" url로 이동")
     @GetMapping("/user/login")
-    public Boolean login(HttpServletResponse httpServletResponse){
+    public void login(HttpServletResponse httpServletResponse){
         try {
             httpServletResponse.sendRedirect("/oauth2/authorization/google");
-            return true;
         } catch (IOException e) {
             log.error("요청 처리 중 문제가 발생했습니다: {}", e);
-            return false;
         }
     }
 
@@ -104,9 +97,8 @@ public class UserController {
 
     @ApiOperation(value = "로그인 유무", notes = "로그인 한 경우, true 반환 | 로그인 하지 않은 경우, false 반환")
     @GetMapping("/user/status")
-    public Boolean getUserStatus() {
-        SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
-        if (sessionUser != null) {
+    public Boolean getUserStatus(@LoginUser SessionUser user) {
+        if (user != null) {
             return true;
         } else {
             return false;


### PR DESCRIPTION
### session에서 유저를 가져오는 부분을 어노테이션으로 개선
* 기존
```
SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
```
* 현재
컨트롤러의 메서드 파라미터에 `@LoginUser SessionUser user`를 작성하기만 하면, 세션에서 정보를 가져올 수 있도록 변경

### LoginUserArgumentResolver 설명
1. `supportsParameter`에서 @LoginUser 어노테이션이 붙어있으면서, SessionUser 클래스이면, resolveArgument 호출
2. `resolveArgument`에서는 세션에서 유저에 대한 정보를 가져옴

### WebConfig에 대한 설명
* 생성된 `LoginUserArgumentResolver`가 스프링에서 인식될 수 있도록 WebMvcConfigurer에 추가
* `HandlerMethodArgumentResolver`는 항상 `webMvcConfigurer`의 `addArgumentResolvers()`를 통해 추가해야함